### PR TITLE
Include `Float` in the list of types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export const relLanguage = LRLanguage.define({
         'output insert delete abort export': t.emphasis,
         'def': t.definitionKeyword,
         'module': t.moduleKeyword,
-        'Any String Int Number Char Missing Floating UnsignedInt SignedInt Rational FixedDecimal RelName Entity AutoNumber Hash FilePos Date DateTime Year Month Week Day Hour Minute Second Millisecond Microsecond Nanosecond Boolean':
+        'Any String Int Number Char Missing Float Floating UnsignedInt SignedInt Rational FixedDecimal RelName Entity AutoNumber Hash FilePos Date DateTime Year Month Week Day Hour Minute Second Millisecond Microsecond Nanosecond Boolean':
           t.typeName,
         Number: t.number,
         BooleanLiteral: t.bool,


### PR DESCRIPTION
I'm not sure if this omission was deliberate, but it seems we could include `Float` in the list of types to be highlighted.